### PR TITLE
feat(skills): migrate from TypeORM to Mongoose

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,10 +7,12 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 import { MongooseModule } from '@nestjs/mongoose';
+import { SkillsModule } from './skills/skills.module';
 
 @Module({
   imports: [
     UsersModule,
+    SkillsModule,
     MongooseModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (config: ConfigService) => {

--- a/src/skills/dtos/create-skill.dto.ts
+++ b/src/skills/dtos/create-skill.dto.ts
@@ -1,0 +1,19 @@
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+export class CreateSkillDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(3, { message: 'Name should be at least 3 characters long' })
+  @MaxLength(100, { message: 'Name should not exceed 100 characters' })
+  title: string;
+  @IsString()
+  @IsOptional()
+  @MaxLength(500, { message: 'Description should not exceed 500 characters' })
+  description?: string;
+}

--- a/src/skills/dtos/update-skill.dto.ts
+++ b/src/skills/dtos/update-skill.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSkillDto } from './create-skill.dto';
+
+export class UpdateSkillDto extends PartialType(CreateSkillDto) {}

--- a/src/skills/skill.schema.ts
+++ b/src/skills/skill.schema.ts
@@ -1,0 +1,18 @@
+import { User } from 'src/users/user.schema';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+import { Type } from 'class-transformer';
+export type SkillDocument = Skill & Document;
+
+@Schema({ timestamps: true })
+export class Skill {
+  @Prop({ type: String, required: true, maxlength: 100 })
+  title: string;
+  @Prop({ type: String, required: false })
+  description: string;
+
+  @Type(() => User)
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  user: Types.ObjectId | User;
+}
+export const SkillSchema = SchemaFactory.createForClass(Skill);

--- a/src/skills/skills.controller.ts
+++ b/src/skills/skills.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { SkillsService } from './skills.service';
+import { AuthRolesGuard } from 'src/users/guards/auth-roles.guard';
+import { Roles } from 'src/users/decorators/user-role.decorator';
+import { UserRole } from 'src/utils/enums';
+import { CreateSkillDto } from './dtos/create-skill.dto';
+import { CurrentUser } from 'src/users/decorators/current-user.decorator';
+import { JWTPayloadType } from 'src/utils/types';
+import { UpdateSkillDto } from './dtos/update-skill.dto';
+
+@Controller('api/skills')
+export class SkillsController {
+  constructor(private readonly skillsService: SkillsService) {}
+  @Post()
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.MENTOR)
+  public async createNewSkill(
+    @Body() createSkill: CreateSkillDto,
+    @CurrentUser() paylod: JWTPayloadType,
+  ) {
+    const skill = await this.skillsService.CreateSkill(createSkill, paylod.id);
+
+    return skill;
+  }
+  @Get()
+  public getAllSkills() {
+    return this.skillsService.getAllSkills();
+  }
+  @Get(':id')
+  public getSingleSkill(@Param('id') id: string) {
+    return this.skillsService.getSkillBy(id);
+  }
+  @Put(':id')
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.MENTOR)
+  public updateSkill(
+    @Param('id') id: string,
+    @Body() updateSkill: UpdateSkillDto,
+  ) {
+    return this.skillsService.updateSkill(id, updateSkill);
+  }
+  @Delete(':id')
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.MENTOR)
+  public deleteSkill(@Param('id') id: string) {
+    return this.skillsService.deleteSkill(id);
+  }
+}

--- a/src/skills/skills.module.ts
+++ b/src/skills/skills.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { SkillsController } from './skills.controller';
+import { SkillsService } from './skills.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Skill, SkillSchema } from './skill.schema';
+import { UsersModule } from 'src/users/users.module';
+import { JwtModule } from '@nestjs/jwt';
+import { MongooseModule } from '@nestjs/mongoose';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Skill.name, schema: SkillSchema }]),
+
+    UsersModule,
+    JwtModule,
+  ],
+  controllers: [SkillsController],
+  providers: [SkillsService],
+})
+export class SkillsModule {}

--- a/src/skills/skills.service.ts
+++ b/src/skills/skills.service.ts
@@ -1,0 +1,96 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Skill, SkillDocument } from './skill.schema';
+import { UsersService } from 'src/users/users.service';
+import { CreateSkillDto } from './dtos/create-skill.dto';
+import { UpdateSkillDto } from './dtos/update-skill.dto';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { User } from 'src/users/user.schema';
+
+@Injectable()
+export class SkillsService {
+  constructor(
+    @InjectModel(Skill.name)
+    private readonly skillsModel: Model<SkillDocument>,
+  ) {}
+  public async CreateSkill(createSkill: CreateSkillDto, userId: string) {
+    try {
+      const newSkill = await this.skillsModel.create({
+        ...createSkill,
+        user: new Types.ObjectId(userId),
+      });
+      return {
+        ...newSkill.toObject(),
+        _id: newSkill._id.toString(),
+        user: newSkill.user.toString(),
+      };
+    } catch (error) {
+      throw new Error('Failed to create skill');
+    }
+  }
+  public async getAllSkills() {
+    try {
+      const skills = await this.skillsModel
+        .find()
+        .populate('user')
+        .lean()
+        .exec();
+      return skills.map((skill) => ({
+        ...skill,
+        _id: skill._id.toString(),
+        user: skill.user ? (skill.user as any)._id.toString() : null,
+      }));
+    } catch (error) {
+      throw new Error('Failed to retrieve skills');
+    }
+  }
+  public async getSkillBy(id: string) {
+    const skill = await this.skillsModel
+      .findById(id.toString())
+      .populate('user', '_id fullName email userRole')
+      .lean()
+      .exec();
+
+    if (!skill) throw new NotFoundException('Skill not found');
+    const user = skill.user as any;
+
+    return {
+      ...skill,
+      _id: skill._id.toString(),
+      user: {
+        ...user,
+        _id: user._id ? user._id.toString() : undefined,
+      },
+    };
+  }
+  public async updateSkill(id: string, updateSkill: UpdateSkillDto) {
+    const skill = await this.getSkillBy(id);
+    if (!skill) throw new NotFoundException('Skill not found');
+    const result = await this.skillsModel.updateOne(
+      {
+        _id: id,
+      },
+      { $set: updateSkill },
+    );
+    if (result.modifiedCount === 0) {
+      throw new Error('Failed to update skill');
+    }
+    return { message: 'Skill updated successfully' };
+  }
+  public async deleteSkill(id: string) {
+    try {
+      const skill = await this.skillsModel.findById(id);
+      if (!skill) {
+        throw new NotFoundException('Skill not found');
+      }
+      await this.skillsModel.deleteOne({ _id: id });
+      return { message: 'Skill deleted successfully' };
+    } catch (error) {
+      throw new Error('Failed to delete skill');
+    }
+  }
+}


### PR DESCRIPTION
- Replaced TypeORM Skill entity with Mongoose schema
- Updated Skills service to use Mongoose models instead of TypeORM repository
- Refactored controller methods to work with Mongoose queries
- Modified DTOs and validation to align with Mongoose models
- Updated module imports and dependency injections