### PR TITLE
feat(categories): migrate from TypeORM to Mongoose

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,11 +8,13 @@ import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 import { MongooseModule } from '@nestjs/mongoose';
 import { SkillsModule } from './skills/skills.module';
+import { CategoriesModule } from './categories/categories.module';
 
 @Module({
   imports: [
     UsersModule,
     SkillsModule,
+    CategoriesModule,
     MongooseModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (config: ConfigService) => {

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -1,0 +1,56 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthRolesGuard } from 'src/users/guards/auth-roles.guard';
+import { Roles } from 'src/users/decorators/user-role.decorator';
+import { UserRole } from 'src/utils/enums';
+import { CurrentUser } from 'src/users/decorators/current-user.decorator';
+import { JWTPayloadType } from 'src/utils/types';
+import { ObjectId } from 'mongodb';
+import { CategoriesService } from './categories.service';
+import { CreateCategoryDto } from './dtos/create-category.dto';
+import { UpdateCategoryDto } from './dtos/update-category.dto';
+
+@Controller('api/categories')
+export class CategoriesController {
+  constructor(private readonly categoriesService: CategoriesService) {}
+  @Post()
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.ADMIN)
+  public createNewCategory(
+    @Body() createCategory: CreateCategoryDto,
+    @CurrentUser() paylod: JWTPayloadType,
+  ) {
+    return this.categoriesService.CreateCategory(createCategory, paylod.id);
+  }
+  @Get()
+  public getAllCategories() {
+    return this.categoriesService.getAllCategories();
+  }
+  @Get(':id')
+  public getSingleCategory(@Param('id') id: string) {
+    return this.categoriesService.getCategoryBy(id);
+  }
+  @Put(':id')
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.ADMIN)
+  public updateCategory(
+    @Param('id') id: string,
+    @Body() updateCategory: UpdateCategoryDto,
+  ) {
+    return this.categoriesService.updateCategory(id, updateCategory);
+  }
+  @Delete(':id')
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.ADMIN)
+  public deleteCategory(@Param('id') id: string) {
+    return this.categoriesService.deleteCategory(id);
+  }
+}

--- a/src/categories/categories.module.ts
+++ b/src/categories/categories.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+import { UsersModule } from 'src/users/users.module';
+import { JwtModule } from '@nestjs/jwt';
+import { Category, CategorySchema } from './category.schema';
+import { MongooseModule } from '@nestjs/mongoose';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Category.name, schema: CategorySchema },
+    ]),
+    UsersModule,
+    JwtModule,
+  ],
+  controllers: [CategoriesController],
+  providers: [CategoriesService],
+  exports: [CategoriesService],
+})
+export class CategoriesModule {}

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -1,0 +1,107 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UsersService } from 'src/users/users.service';
+import { Category, CategoryDocument } from './category.schema';
+import { CreateCategoryDto } from './dtos/create-category.dto';
+import { UpdateCategoryDto } from './dtos/update-category.dto';
+import { ObjectId } from 'mongodb';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+
+@Injectable()
+export class CategoriesService {
+  constructor(
+    @InjectModel(Category.name)
+    private readonly categoriesModel: Model<CategoryDocument>,
+    private readonly usersService: UsersService,
+  ) {}
+  public async CreateCategory(
+    createCategory: CreateCategoryDto,
+    userId: string,
+  ) {
+    try {
+      const newCategory = await this.categoriesModel.create({
+        ...createCategory,
+        user: new Types.ObjectId(userId),
+      });
+      return {
+        ...newCategory.toObject(),
+        _id: newCategory._id.toString(),
+        user: newCategory.user.toString(),
+      };
+    } catch (error) {
+      throw new Error('Failed to create category');
+    }
+  }
+  public async getAllCategories() {
+    const categories = await this.categoriesModel
+      .find()
+      .populate('user')
+      .lean()
+      .exec();
+    return categories.map((category) => ({
+      ...category,
+      _id: category._id.toString(),
+      user: category.user ? (category.user as any)._id.toString() : null,
+    }));
+  }
+  public async getCategoryBy(id: string) {
+    try {
+      const category = await this.categoriesModel
+        .findById(id.toString())
+        .populate('user', '_id fullName email userRole')
+        .lean()
+        .exec();
+      if (!category) throw new NotFoundException('Category not found');
+      const user = category.user as any;
+
+      return {
+        ...category,
+        _id: category._id.toString(),
+        user: {
+          ...user,
+          _id: user._id ? user._id.toString() : undefined,
+        },
+      };
+    } catch (error) {
+      throw new Error('Failed to retrieve category');
+    }
+  }
+  public async updateCategory(id: string, updateCategory: UpdateCategoryDto) {
+    try {
+      const category = await this.getCategoryBy(id);
+      if (!category) throw new NotFoundException('Category not found');
+      const result = await this.categoriesModel.updateOne(
+        {
+          _id: id,
+        },
+        { $set: updateCategory },
+      );
+
+      if (result.modifiedCount === 0) {
+        throw new Error('Failed to update category');
+      }
+      return { message: 'Category updated successfully' };
+    } catch (error) {
+      throw new Error('Failed to update category');
+    }
+  }
+
+  public async deleteCategory(id: string) {
+    try {
+      const category = await this.categoriesModel.findById(id);
+      if (!category) {
+        throw new NotFoundException('Category not found');
+      }
+      await this.categoriesModel.deleteOne({ _id: id });
+      return { message: 'Category deleted successfully' };
+    } catch (error) {
+      throw new Error('Failed to delete category');
+    }
+  }
+}

--- a/src/categories/category.schema.ts
+++ b/src/categories/category.schema.ts
@@ -1,0 +1,16 @@
+import { User } from 'src/users/user.schema';
+import { Document, Types } from 'mongoose';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+
+export type CategoryDocument = Category & Document;
+
+@Schema({ timestamps: true })
+export class Category {
+  @Prop({ type: String, required: true, maxlength: 100 })
+  title: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  user: Types.ObjectId | User;
+}
+
+export const CategorySchema = SchemaFactory.createForClass(Category);

--- a/src/categories/dtos/create-category.dto.ts
+++ b/src/categories/dtos/create-category.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateCategoryDto {
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(3, { message: 'Title should be at least 3 characters long' })
+  @MaxLength(100, { message: 'Title should not exceed 100 characters' })
+  title: string;
+}

--- a/src/categories/dtos/update-category.dto.ts
+++ b/src/categories/dtos/update-category.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCategoryDto } from './create-category.dto';
+
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}


### PR DESCRIPTION
- Replaced TypeORM Category entity with Mongoose schema
- Updated Categories service to use Mongoose models instead of TypeORM repository
- Refactored controller methods to work with Mongoose queries
- Adjusted DTOs and validation for Mongoose compatibility
- Updated module imports and dependency injections