### PR TITLE
feat(blogs): migrate from TypeORM to Mongoose

### DIFF
--- a/src/blogs/blog.schema.ts
+++ b/src/blogs/blog.schema.ts
@@ -1,0 +1,33 @@
+import { Category } from 'src/categories/category.schema';
+import { User } from 'src/users/user.schema';
+import { BlogStatus } from 'src/utils/enums';
+import { Document, Types } from 'mongoose';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+
+export type BlogDocument = Blog & Document;
+
+@Schema({ timestamps: true })
+export class Blog {
+  @Prop({ type: String, required: true, maxlength: 250 })
+  title: string;
+  @Prop({ type: String, required: true })
+  content: string;
+  @Prop({
+    type: String,
+    enum: BlogStatus,
+    default: BlogStatus.DRAFT,
+    required: true,
+  })
+  status: BlogStatus;
+  @Prop({ type: String, required: false, default: null })
+  blogImage?: string;
+  @Prop({ type: String, required: true })
+  summary: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'Category', required: true })
+  category: Types.ObjectId;
+
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  user: Types.ObjectId;
+}
+export const BlogSchema = SchemaFactory.createForClass(Blog);

--- a/src/blogs/blogs.controller.ts
+++ b/src/blogs/blogs.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { BlogsService } from './blogs.service';
+import { AuthRolesGuard } from 'src/users/guards/auth-roles.guard';
+import { Roles } from 'src/users/decorators/user-role.decorator';
+import { UserRole } from 'src/utils/enums';
+import { CreateBlogDto } from './dtos/create-blog.dto';
+import { CurrentUser } from 'src/users/decorators/current-user.decorator';
+import { JWTPayloadType } from 'src/utils/types';
+import { UpdateBlogDto } from './dtos/update-blog.dto';
+import { FileInterceptor } from '@nestjs/platform-express';
+
+@Controller('api/blogs')
+export class BlogsController {
+  constructor(private readonly blogsService: BlogsService) {}
+
+  @Post()
+  @UseInterceptors(FileInterceptor('blogImage'))
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.MENTOR)
+  public createNewBlog(
+    @Body() createBlog: CreateBlogDto,
+    @CurrentUser() payload: JWTPayloadType,
+    @UploadedFile() file?: Express.Multer.File,
+  ) {
+    console.log('File received:', file);
+
+    if (file) {
+      createBlog.blogImage = file.filename;
+      console.log('File saved as:', file.filename);
+    }
+    return this.blogsService.createBlog(
+      createBlog,
+      payload.id,
+      createBlog.categoryId,
+    );
+  }
+  @Get()
+  public getAllBlogs() {
+    return this.blogsService.getAllBlogs();
+  }
+
+  @Get('/published')
+  public async getAllPublishedBlogs() {
+    try {
+      return await this.blogsService.getAllPublishedBlogs();
+    } catch (error) {
+      console.error('Error fetching blogs:', error);
+      throw error;
+    }
+  }
+  @Get('/:id')
+  public getSingleBlog(@Param('id') id: string) {
+    return this.blogsService.getBlogBy(id);
+  }
+  @Put(':id')
+  @UseInterceptors(FileInterceptor('blogImage'))
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.MENTOR)
+  public updateBlog(
+    @Param('id') id: string,
+    @Body() updateBlog: UpdateBlogDto,
+    @UploadedFile() file?: Express.Multer.File,
+  ) {
+    console.log('File received:', file);
+
+    if (file) {
+      updateBlog.blogImage = file.filename;
+      console.log('File saved as:', file.filename);
+    }
+    return this.blogsService.updateBlog(id, updateBlog);
+  }
+  @Delete(':id')
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.MENTOR)
+  public deleteBlog(@Param('id') id: string, payload: JWTPayloadType) {
+    return this.blogsService.deleteBlog(id, payload);
+  }
+}

--- a/src/blogs/blogs.module.ts
+++ b/src/blogs/blogs.module.ts
@@ -1,0 +1,46 @@
+import { BadRequestException, Module } from '@nestjs/common';
+import { BlogsService } from './blogs.service';
+import { BlogsController } from './blogs.controller';
+import { Blog, BlogSchema } from './blog.schema';
+import { JwtModule } from '@nestjs/jwt';
+import { UsersModule } from 'src/users/users.module';
+import { CategoriesModule } from 'src/categories/categories.module';
+import { MulterModule } from '@nestjs/platform-express';
+import { diskStorage } from 'multer';
+import { mkdirSync } from 'fs';
+import { join } from 'path';
+import { MongooseModule } from '@nestjs/mongoose';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Blog.name, schema: BlogSchema }]),
+    JwtModule,
+    UsersModule,
+    CategoriesModule,
+    MulterModule.register({
+      storage: diskStorage({
+        destination: (req, file, callback) => {
+          const uploadPath = join(process.cwd(), 'images', 'blogs');
+          mkdirSync(uploadPath, { recursive: true });
+          callback(null, uploadPath);
+        },
+        filename(req, file, callback) {
+          const prefix = `${Date.now()}-${Math.round(Math.random() * 1000000)}`;
+          const filename = `${prefix}-${file.originalname}`;
+          callback(null, filename);
+        },
+      }),
+      fileFilter: (req, file, callback) => {
+        if (file.mimetype.startsWith('image')) {
+          callback(null, true);
+        } else {
+          callback(new BadRequestException('Unsupported file format'), false);
+        }
+      },
+      limits: { fileSize: 1024 * 1024 * 5 },
+    }),
+  ],
+  providers: [BlogsService],
+  controllers: [BlogsController],
+})
+export class BlogsModule {}

--- a/src/blogs/blogs.service.ts
+++ b/src/blogs/blogs.service.ts
@@ -1,0 +1,187 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Blog, BlogDocument } from './blog.schema';
+import { Repository } from 'typeorm';
+import { UsersService } from 'src/users/users.service';
+import { CreateBlogDto } from './dtos/create-blog.dto';
+import { ObjectId } from 'mongodb';
+import { BlogStatus } from 'src/utils/enums';
+import { CategoriesService } from 'src/categories/categories.service';
+import { UpdateBlogDto } from './dtos/update-blog.dto';
+import { join } from 'path';
+import { unlinkSync } from 'fs';
+import { JWTPayloadType } from 'src/utils/types';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+
+@Injectable()
+export class BlogsService {
+  constructor(
+    @InjectModel(Blog.name)
+    private readonly blogsModel: Model<BlogDocument>,
+    private readonly usersService: UsersService,
+    private readonly categoriesService: CategoriesService,
+  ) {}
+  public async createBlog(
+    createBlog: CreateBlogDto,
+    userId: string,
+    categoryId: string,
+  ) {
+    try {
+      const { blogImage } = createBlog;
+      let newBlog = await this.blogsModel.create({
+        ...createBlog,
+        title: createBlog.title,
+        content: createBlog.content,
+        status: createBlog.status ?? BlogStatus.ARCHIVED,
+        blogImage: blogImage ? `/images/blogs/${blogImage}` : null,
+        user: new Types.ObjectId(userId),
+        category: new Types.ObjectId(categoryId),
+      });
+      return {
+        ...newBlog.toObject(),
+        _id: newBlog._id.toString(),
+        user: newBlog.user.toString(),
+        category: newBlog.category.toString(),
+      };
+    } catch (error) {
+      throw new Error('Failed to create blog');
+    }
+  }
+  public async getAllBlogs() {
+    try {
+      const blogs = await this.blogsModel.find().lean().exec();
+      return blogs.map((blog) => ({
+        ...blog,
+        _id: blog._id.toString(),
+        user: {
+          _id: blog.user._id.toString(),
+        },
+        category: {
+          _id: blog.category._id.toString(),
+        },
+      }));
+    } catch (error) {
+      throw new Error('Failed to retrieve blogs');
+    }
+  }
+  public async getAllPublishedBlogs() {
+    try {
+      const blogs = await this.blogsModel
+        .find({ status: BlogStatus.PUBLISHED })
+        .lean()
+        .exec();
+      return blogs.map((blog) => ({
+        ...blog,
+        _id: blog._id.toString(),
+        user: {
+          _id: blog.user._id.toString(),
+        },
+        category: {
+          _id: blog.category._id.toString(),
+        },
+      }));
+    } catch (error) {
+      console.error('Error fetching published blogs:', error);
+      throw error;
+    }
+  }
+  public async getBlogBy(id: string) {
+    try {
+      const blog = await this.blogsModel
+        .findById(id.toString())
+        .populate('user', '_id fullName')
+        .populate('category', '_id title')
+        .lean()
+        .exec();
+      if (!blog) throw new NotFoundException('Blog not found');
+      return {
+        ...blog,
+        _id: blog._id.toString(),
+        user: blog.user
+          ? {
+              ...(blog.user as any),
+              _id: (blog.user as any)._id.toString(),
+              fullName: (blog.user as any).fullName.toString(),
+            }
+          : null,
+        category: blog.category
+          ? {
+              ...(blog.category as any),
+              _id: (blog.category as any)._id.toString(),
+              title: (blog.category as any).title.toString(),
+            }
+          : null,
+      };
+    } catch (error) {
+      throw new Error('Failed to retrieve blog');
+    }
+  }
+  public async updateBlog(id: string, updateBlog: UpdateBlogDto) {
+    try {
+      const { blogImage } = updateBlog;
+      const blog = await this.getBlogBy(id);
+      if (!blog) throw new NotFoundException('Blog not found');
+
+      if (blogImage) {
+        if (blog.blogImage) {
+          await this.removeBlogImage(id);
+        }
+      }
+      const result = await this.blogsModel.updateOne(
+        { _id: id },
+        {
+          $set: {
+            ...updateBlog,
+            blogImage: blogImage
+              ? `/images/blogs/${blogImage}`
+              : blog.blogImage,
+          },
+        },
+      );
+      if (result.modifiedCount === 0) {
+        throw new Error('Failed to update blog');
+      }
+      return { message: 'Blog updated successfully' };
+    } catch (error) {
+      throw new Error('Failed to update blog');
+    }
+  }
+  public async deleteBlog(blogId: string, payload: JWTPayloadType) {
+    try {
+      const blog = await this.getBlogBy(blogId);
+      if (blog.blogImage) {
+        await this.removeBlogImage(blogId);
+      }
+      await this.blogsModel.deleteOne({ _id: blogId });
+      return { message: 'Blog has been deleted successfully' };
+    } catch (error) {
+      throw new Error('Failed to delete blog');
+    }
+  }
+
+  public async removeBlogImage(blogId: string) {
+    const blog = await this.getBlogBy(blogId);
+    if (!blog.blogImage) {
+      throw new BadRequestException('There is no blog image');
+    } else {
+      const filename = blog.blogImage.split('/').pop();
+
+      const imagePath = join(process.cwd(), `./images/blogs/${filename}`);
+      try {
+        unlinkSync(imagePath);
+        await this.blogsModel.updateOne(
+          { _id: blogId },
+          { $set: { blogImage: null } },
+        );
+        return { message: 'Blog image removed successfully' };
+      } catch (error) {
+        throw new Error('Failed to remove blog image');
+      }
+    }
+  }
+}

--- a/src/blogs/dtos/create-blog.dto.ts
+++ b/src/blogs/dtos/create-blog.dto.ts
@@ -1,0 +1,29 @@
+import {
+  IsMongoId,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+import { BlogStatus } from 'src/utils/enums';
+
+export class CreateBlogDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(250)
+  title: string;
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+  @IsString()
+  @IsOptional()
+  blogImage?: string;
+  @IsString()
+  @IsNotEmpty()
+  summary: string;
+  @IsOptional()
+  status?: BlogStatus;
+  @IsMongoId()
+  @IsNotEmpty()
+  categoryId: string;
+}

--- a/src/blogs/dtos/update-blog.dto.ts
+++ b/src/blogs/dtos/update-blog.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateBlogDto } from './create-blog.dto';
+
+export class UpdateBlogDto extends PartialType(CreateBlogDto) {}


### PR DESCRIPTION
- Replaced TypeORM Blog entity with Mongoose schema
- Updated Blogs service to use Mongoose models instead of TypeORM repository
- Refactored controller methods to work with Mongoose queries
- Adjusted DTOs and validation for Mongoose compatibility
- Updated module imports and dependency injections
- Modified database operations (CRUD) to use Mongoose methods