### PR TITLE
feat(services): migrate from TypeORM to Mongoose

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,12 +9,16 @@ import { join } from 'path';
 import { MongooseModule } from '@nestjs/mongoose';
 import { SkillsModule } from './skills/skills.module';
 import { CategoriesModule } from './categories/categories.module';
+import { BlogsModule } from './blogs/blogs.module';
+import { ServicesModule } from './services/services.module';
 
 @Module({
   imports: [
     UsersModule,
     SkillsModule,
     CategoriesModule,
+    BlogsModule,
+    ServicesModule,
     MongooseModule.forRootAsync({
       inject: [ConfigService],
       useFactory: (config: ConfigService) => {

--- a/src/services/dtos/create-service.dto.ts
+++ b/src/services/dtos/create-service.dto.ts
@@ -1,0 +1,45 @@
+import { Transform } from 'class-transformer';
+import {
+  IsMongoId,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { ServiceStatus } from 'src/utils/enums';
+
+export class CreateServiceDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  title: string;
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+  @IsString()
+  @IsOptional()
+  serviceImage?: string;
+  @IsNumber()
+  @IsNotEmpty()
+  @Min(1)
+  @Transform(({ value }) => Number(value))
+  duration: number;
+  @IsNumber()
+  @IsNotEmpty()
+  @IsPositive()
+  @Min(0)
+  @Transform(({ value }) => Number(value))
+  price: number;
+  @IsNumber()
+  @IsNotEmpty()
+  @Min(1)
+  @Transform(({ value }) => Number(value))
+  numberOfPlaces: number;
+  @IsOptional()
+  status?: ServiceStatus;
+  @IsNotEmpty()
+  categoryId: string;
+}

--- a/src/services/dtos/update-blog.dto.ts
+++ b/src/services/dtos/update-blog.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateServiceDto } from './create-service.dto';
+
+export class UpdateServiceDto extends PartialType(CreateServiceDto) {}

--- a/src/services/service.schema.ts
+++ b/src/services/service.schema.ts
@@ -1,0 +1,49 @@
+import { Category } from 'src/categories/category.schema';
+import { User } from 'src/users/user.schema';
+import { ServiceStatus } from 'src/utils/enums';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+export type ServiceDocument = Service & Document;
+
+@Schema({ timestamps: true })
+export class Service {
+  @Prop({ type: String, required: true })
+  title: string;
+  @Prop({ type: String, required: true })
+  description: string;
+  @Prop({
+    type: String,
+    enum: ServiceStatus,
+    default: ServiceStatus.AVAILABLE,
+    required: true,
+  })
+  status: ServiceStatus;
+  @Prop({ type: String, required: false, default: null })
+  serviceImage?: string;
+  @Prop({ type: Number, required: true })
+  duration: number;
+  @Prop({
+    type: Number,
+    required: true,
+    get: (value: number) => value.toFixed(2),
+    set: (value: number) => parseFloat(value.toFixed(2)),
+  })
+  price: number;
+  @Prop({ type: Number, required: true })
+  numberOfPlaces: number;
+  @Prop({
+    type: Types.ObjectId,
+    ref: 'User',
+    required: true,
+  })
+  user: Types.ObjectId | User;
+
+  @Prop({
+    type: Types.ObjectId,
+    ref: 'Category',
+    required: true,
+  })
+  category: Types.ObjectId | Category;
+}
+
+export const ServiceSchema = SchemaFactory.createForClass(Service);

--- a/src/services/services.controller.ts
+++ b/src/services/services.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { AuthRolesGuard } from 'src/users/guards/auth-roles.guard';
+import { Roles } from 'src/users/decorators/user-role.decorator';
+import { UserRole } from 'src/utils/enums';
+import { CurrentUser } from 'src/users/decorators/current-user.decorator';
+import { JWTPayloadType } from 'src/utils/types';
+import { ServicesService } from './services.service';
+import { CreateServiceDto } from './dtos/create-service.dto';
+import { UpdateServiceDto } from './dtos/update-blog.dto';
+import { FileInterceptor } from '@nestjs/platform-express';
+
+@Controller('api/services')
+export class ServicesController {
+  constructor(private readonly servicesService: ServicesService) {}
+
+  @Post()
+  @UseInterceptors(FileInterceptor('serviceImage'))
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.MENTOR)
+  public createNewService(
+    @Body() createService: CreateServiceDto,
+    @CurrentUser() payload: JWTPayloadType,
+    @UploadedFile() file?: Express.Multer.File,
+  ) {
+    console.log('File received:', file);
+
+    if (file) {
+      createService.serviceImage = file.filename;
+      console.log('File saved as:', file.filename);
+    }
+    return this.servicesService.createService(
+      createService,
+      payload.id,
+      createService.categoryId,
+    );
+  }
+  @Get()
+  public getAllServices() {
+    return this.servicesService.getAllServices();
+  }
+
+  @Get(':id')
+  public getServiceById(@Param('id') id: string) {
+    return this.servicesService.getServiceBy(id);
+  }
+
+  @Put(':id')
+  @UseInterceptors(FileInterceptor('serviceImage'))
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.MENTOR)
+  public updateService(
+    @Param('id') id: string,
+    @Body() updateService: UpdateServiceDto,
+    @UploadedFile() file?: Express.Multer.File,
+  ) {
+    console.log('File received:', file);
+
+    if (file) {
+      updateService.serviceImage = file.filename;
+      console.log('File saved as:', file.filename);
+    }
+    return this.servicesService.updateService(id, updateService);
+  }
+  @Delete(':id')
+  @UseGuards(AuthRolesGuard)
+  @Roles(UserRole.MENTOR)
+  public deleteService(@Param('id') id: string, payload: JWTPayloadType) {
+    return this.servicesService.deleteService(id, payload);
+  }
+}

--- a/src/services/services.module.ts
+++ b/src/services/services.module.ts
@@ -1,0 +1,47 @@
+import { BadRequestException, Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtModule } from '@nestjs/jwt';
+import { UsersModule } from 'src/users/users.module';
+import { CategoriesModule } from 'src/categories/categories.module';
+import { Service, ServiceSchema } from './service.schema';
+import { ServicesService } from './services.service';
+import { ServicesController } from './services.controller';
+import { MulterModule } from '@nestjs/platform-express';
+import { diskStorage } from 'multer';
+import { join } from 'path';
+import { mkdirSync } from 'fs';
+import { MongooseModule } from '@nestjs/mongoose';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Service.name, schema: ServiceSchema }]),
+    JwtModule,
+    UsersModule,
+    CategoriesModule,
+    MulterModule.register({
+      storage: diskStorage({
+        destination: (req, file, callback) => {
+          const uploadPath = join(process.cwd(), 'images', 'services');
+          mkdirSync(uploadPath, { recursive: true });
+          callback(null, uploadPath);
+        },
+        filename(req, file, callback) {
+          const prefix = `${Date.now()}-${Math.round(Math.random() * 1000000)}`;
+          const filename = `${prefix}-${file.originalname}`;
+          callback(null, filename);
+        },
+      }),
+      fileFilter: (req, file, callback) => {
+        if (file.mimetype.startsWith('image')) {
+          callback(null, true);
+        } else {
+          callback(new BadRequestException('Unsupported file format'), false);
+        }
+      },
+      limits: { fileSize: 1024 * 1024 * 2 },
+    }),
+  ],
+  providers: [ServicesService],
+  controllers: [ServicesController],
+})
+export class ServicesModule {}

--- a/src/services/services.service.ts
+++ b/src/services/services.service.ts
@@ -1,0 +1,168 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { ServiceStatus } from 'src/utils/enums';
+import { join } from 'path';
+import { unlinkSync } from 'fs';
+import { JWTPayloadType } from 'src/utils/types';
+import { Service, ServiceDocument } from './service.schema';
+import { CreateServiceDto } from './dtos/create-service.dto';
+import { UpdateServiceDto } from './dtos/update-blog.dto';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+
+@Injectable()
+export class ServicesService {
+  constructor(
+    @InjectModel(Service.name)
+    private readonly servicesModel: Model<ServiceDocument>,
+  ) {}
+  public async createService(
+    createService: CreateServiceDto,
+    userId: string,
+    categoryId: string,
+  ) {
+    try {
+      const { serviceImage } = createService;
+      let newService = await this.servicesModel.create({
+        ...createService,
+        title: createService.title,
+        description: createService.description,
+        status: createService.status ?? ServiceStatus.AVAILABLE,
+        serviceImage: serviceImage ? `/images/services/${serviceImage}` : null,
+        duration: createService.duration,
+        price: createService.price,
+        numberOfPlaces: createService.numberOfPlaces,
+        user: new Types.ObjectId(userId),
+        category: new Types.ObjectId(categoryId),
+      });
+      const savedService = await this.servicesModel
+        .findById(newService._id)
+        .lean()
+        .exec();
+      return {
+        ...savedService,
+        _id: savedService._id.toString(),
+        user: savedService.user.toString(),
+        category: savedService.category.toString(),
+      };
+    } catch (error) {
+      throw new Error('Failed to create service');
+    }
+  }
+  public async getAllServices() {
+    try {
+      const services = await this.servicesModel.find().lean().exec();
+      return services.map((service) => ({
+        ...service,
+        _id: service._id.toString(),
+        user: {
+          _id: (service.user as any)._id.toString(),
+        },
+        category: {
+          _id: (service.category as any)._id.toString(),
+        },
+      }));
+    } catch (error) {
+      throw new Error('Failed to retrieve services');
+    }
+  }
+
+  public async getServiceBy(id: string) {
+    try {
+      const service = await this.servicesModel
+        .findById(id.toString())
+        .populate('user', '_id fullName')
+        .populate('category', '_id title')
+        .lean()
+        .exec();
+      if (!service) throw new NotFoundException('Service not found');
+      return {
+        ...service,
+        _id: service._id.toString(),
+        user: service.user
+          ? {
+              ...(service.user as any),
+              _id: (service.user as any)._id.toString(),
+            }
+          : null,
+        category: service.category
+          ? {
+              ...(service.category as any),
+              _id: (service.category as any)._id.toString(),
+            }
+          : null,
+      };
+    } catch (error) {
+      throw new Error('Failed to retrieve service');
+    }
+  }
+  public async updateService(id: string, updateService: UpdateServiceDto) {
+    try {
+      const { serviceImage } = updateService;
+      const service = await this.getServiceBy(id);
+
+      if (serviceImage && service.serviceImage) {
+        await this.removeServiceImage(id);
+      }
+      const result = await this.servicesModel.updateOne(
+        { _id: id },
+        {
+          $set: {
+            ...updateService,
+            serviceImage: serviceImage
+              ? `/images/services/${serviceImage}`
+              : service.serviceImage,
+          },
+        },
+      );
+
+      if (result.modifiedCount === 0) {
+        throw new Error('Failed to update service');
+      }
+
+      return { message: 'Service updated successfully' };
+    } catch (error) {
+      console.error('Error updating service:', error);
+      throw new BadRequestException('Failed to update service');
+    }
+  }
+  public async deleteService(serviceId: string, payload: JWTPayloadType) {
+    try {
+      const service = await this.getServiceBy(serviceId);
+      if (service.serviceImage) {
+        await this.removeServiceImage(serviceId);
+      }
+      await this.servicesModel.deleteOne({ _id: serviceId });
+      return { message: 'Service has been deleted successfully' };
+    } catch (error) {
+      throw new Error('Failed to delete service');
+    }
+  }
+
+  public async removeServiceImage(serviceId: string) {
+    const service = await this.getServiceBy(serviceId);
+    if (!service.serviceImage) {
+      throw new BadRequestException('There is no service image');
+    } else {
+      const filename = service.serviceImage.split('/').pop();
+      console.log('filename is ', filename);
+
+      const imagePath = join(process.cwd(), `./images/services/${filename}`);
+      console.log(service.serviceImage);
+      try {
+        unlinkSync(imagePath);
+        await this.servicesModel.updateOne(
+          { _id: serviceId },
+          { $set: { serviceImage: null } },
+        );
+        return { message: 'Service image removed successfully' };
+      } catch (error) {
+        throw new Error('Failed to remove service image');
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Replaced TypeORM repositories with Mongoose models for Users, Skills, Categories, and Blogs
- Updated all service methods to use Mongoose queries (ind, indOne, create, save, deleteOne, etc.)
- Refactored DTOs and validation to align with Mongoose schemas
- Adjusted controllers to handle Mongoose-based responses
- Updated dependency injections to use @InjectModel() instead of @InjectRepository()
- Removed TypeORM decorators and replaced them with Mongoose schema definitions