### PR TITLE
CNL-118: test: add unit tests for getAllCategories method in Category Service

### DIFF
--- a/src/categories/categories.spec.ts
+++ b/src/categories/categories.spec.ts
@@ -109,4 +109,39 @@ describe('CategoriesService', () => {
       });
     });
   });
+  describe('getAllCategories', () => {
+    it('should return all categories successfully', async () => {
+      findMock.mockReturnValue({
+        populate: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue(mockCategories),
+      });
+
+      const result = await category.getAllCategories();
+
+      expect(findMock).toHaveBeenCalled();
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        ...mockCategories[0],
+        user: mockCategories[0].user._id.toString(),
+      });
+      expect(result[1]).toEqual({
+        ...mockCategories[1],
+        user: mockCategories[1].user._id.toString(),
+      });
+    });
+
+    it('should throw an error if categories retrieval fails', async () => {
+      findMock.mockReturnValue({
+        populate: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockRejectedValue(new Error('Database error')),
+      });
+
+      await expect(category.getAllCategories()).rejects.toThrow(
+        'Failed to retrieve categories',
+      );
+      expect(findMock).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
- Implemented unit tests to validate the successful retrieval of all categories
- Mocked the Mongoose model and covered scenarios where data is successfully retrieved and where retrieval fails
- Ensured proper error handling when categories cannot be fetched